### PR TITLE
Fix research on mobile

### DIFF
--- a/themes/brevis/static/css/style.css
+++ b/themes/brevis/static/css/style.css
@@ -374,6 +374,21 @@ time
   }
 }
 
+@media only screen and (max-width: 690px) {
+  .card-tool {
+    display: block;
+  }
+  .tool-left {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+
+
+
+
 article.news
 {
   margin-bottom: 1em;


### PR DESCRIPTION
Fixed the layout for mobile of the research boxes. 
- Text box is placed below the image/logo of the tool. 
- Via media query.
