### PR TITLE
Update to ES profile, small bug fix

### DIFF
--- a/data/people/ES.toml
+++ b/data/people/ES.toml
@@ -13,4 +13,7 @@ German. She is always keen to play some soccer and is hoping to pick up
 the flute again.
 """
 github  = "emsimons"
+web = "https://emsimons.github.io/me/"
+orcid = "0009-0001-5725-594X"
+bluesky = "emsimons.bsky.social"
 twitter = "simons_emilym"

--- a/layouts/shortcodes/person.html
+++ b/layouts/shortcodes/person.html
@@ -17,7 +17,7 @@
 
       {{ with $person.orcid }}
       <li>
-        <a href="{{ . }}">
+        <a href="https://orcid.org/{{ . }}">
             <img src="/icons/orcid.svg" alt="ORCID" />
           </a>
       </li>


### PR DESCRIPTION
# Two quick edits

1. Added personal website, Bluesky, and ORCID to ES profile -> in `data/people/ES.toml`
2. Fixed broken ORCID links (added missing "https://orcid.org/" prefix) -> in `layouts/shortcodes/person.html`